### PR TITLE
Fix the not fixed conflict error

### DIFF
--- a/recovery.cpp
+++ b/recovery.cpp
@@ -890,12 +890,7 @@ Device::BuiltinAction start_recovery(Device* device, const std::vector<std::stri
   std::string ver = android::base::GetProperty("ro.modversion", "");
 
   std::vector<std::string> title_lines = {
-<<<<<<< HEAD
-    "Version " + android::base::GetProperty("ro.blackiron.build.version", "(unknown)") +
-        " (" + ver_date + ")",
-=======
     "Version " + android::base::GetProperty("ro.blackiron.build.version", "(unknown)"),
->>>>>>> bc603e4d (recovery: Drop useless version date)
   };
   title_lines.push_back("Product name - " + android::base::GetProperty("ro.product.device", ""));
   if (android::base::GetBoolProperty("ro.build.ab_update", false)) {


### PR DESCRIPTION
There is error in following commit.
https://github.com/Black-Iron-Project/bootable_recovery/commit/875678903f068bb995e6e6877dd5846bbd3c0202
https://github.com/Black-Iron-Project/bootable_recovery/blob/24a425ef5f75acf2bc68e9deb7793ddda9402977/recovery.cpp#L893-L898

In this commit, mske declaration of ""ver_date"  dropped, therefore, confilict porsion of HEADR side should get rid of it.

### Explanation of background reached that I found error.
I don't consider that branch of u14 is correct branch as default branch.
Meanwhile, I knew that branch of u14 is latest branch by confirming the Network Graph on repository of manifest.
https://github.com/Black-Iron-Project/manifest/network
During the building by using branch of u14, I found this error.